### PR TITLE
Show up arrow after 600ms

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -379,7 +379,7 @@ ul.footer-menu li a:hover {
 .footer-arrow-img {
     height: 32px;
     width: 48px;
-    opacity: .7;
+    opacity: 0;
 }
 
 .footer-arrow-img:hover {

--- a/src/js/upScroll.js
+++ b/src/js/upScroll.js
@@ -1,11 +1,11 @@
 $(document).ready(function () {
     var documentHeight = $(document).height();
     var windowHeight = $(window).height();
-    var $arrow = $('.scrollToTop');
+    var $arrow = $('.footer-arrow-img');
     var showArrow = function () {
         if ($(this).scrollTop() > (documentHeight - windowHeight)) {
             $arrow.delay(600).animate({
-                opacity: 1,
+                opacity: 0.7,
                 duration: 600
             });
         }


### PR DESCRIPTION
The scroll to top arrow was previously always visible. Now it mysteriously fades in 600ms after the user reaches the bottom of the document. Coolness factor = 300 💎  💎  💎 
