### PR TITLE
Https  dev server in prod mode

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -17,7 +17,8 @@ gulp.task('serve', ['build'], () => {
     browserSync.init({
         server: {
             baseDir: './'
-        }
+        },
+        https: !isDev()
     });
     gulp.watch('src/css/**/*.scss', ['build:css']);
     gulp.watch('src/js/*.js', ['build:js']);
@@ -74,15 +75,15 @@ gulp.task('build:html', () => {
         };
     } else {
         data.vendorPaths = {
-            jquery: 'https://code.jquery.com/jquery-3.1.0.min.js',
-            jqueryEasing: 'https://cdnjs.cloudflare.com/ajax/libs/jquery-easing/1.3/jquery.easing.min.js',
-            jqueryVisible: 'https://cdnjs.cloudflare.com/ajax/libs/jquery-visible/1.2.0/jquery.visible.min.js',
-            bootstrap: 'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css',
-            addToCalendarCss: 'https://addtocalendar.com/atc/1.5/atc-style-blue.css',
-            dosis: 'https://fonts.googleapis.com/css?family=Dosis',
-            html5Shiv: 'https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js',
-            respond: 'https://oss.maxcdn.com/respond/1.4.2/respond.min.js',
-            addToCalendarJs: 'https://addtocalendar.com/atc/1.5/atc.min.js'
+            jquery: '//code.jquery.com/jquery-3.1.0.min.js',
+            jqueryEasing: '//cdnjs.cloudflare.com/ajax/libs/jquery-easing/1.3/jquery.easing.min.js',
+            jqueryVisible: '//cdnjs.cloudflare.com/ajax/libs/jquery-visible/1.2.0/jquery.visible.min.js',
+            bootstrap: '//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css',
+            addToCalendarCss: '//addtocalendar.com/atc/1.5/atc-style-blue.css',
+            dosis: '//fonts.googleapis.com/css?family=Dosis',
+            html5Shiv: '//oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js',
+            respond: '//oss.maxcdn.com/respond/1.4.2/respond.min.js',
+            addToCalendarJs: '//addtocalendar.com/atc/1.5/atc.min.js'
         };
     }
     gulp.src('src/templates/index.html')

--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ $ npm start
 
 Navigate to [http://localhost:3000](http://localhost:3000) and implement your changes!
 
+### Production mode
+
+You can also start the dev server in production mode. This runs an HTTPS server, and uses vendor assets served from 
+CDNs, rather than local assets.
+
+```
+$ NODE_ENV=production npm start
+```
+
+### Push
+
 After you've made changes and committed them into Git, push your branch to Github:
 
 ```
@@ -48,4 +59,4 @@ Then go to [our Github repo](https://github.com/WDOTS/wdots.github.io) and creat
 - Before committing, please run `npm run lint` and ensure there are no linting errors or warnings
 - Before raising a pull request please test that the website works in the latest version
  of all major browsers (Chrome, Firefox, Safari, Edge)
-- Before merging a pull request, wait for the build to pass and at least one thumbs-up from another member of WDOTS
+- Before merging a pull request, wait for the build to pass and request a review from at least one other member of WDOTS


### PR DESCRIPTION
# What does this change?

- When starting the dev server in production mode, start an HTTPS server
- Make CDN-hosted vendor assets protocol-agnostic

# Why is this useful?

- We can test that the site works correctly in HTTPS before pushing to production
- If we ever need to disable HTTPS, the vendor assets will revert to HTTP without needing a code change