### PR TITLE
Inline SVGs

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -7,6 +7,7 @@ const sass = require('gulp-sass');
 const sourcemaps = require('gulp-sourcemaps');
 const template = require('gulp-template');
 const htmlmin = require('gulp-htmlmin');
+const inline = require('gulp-inline');
 const browserSync = require('browser-sync').create();
 
 const isDev = function () {
@@ -89,6 +90,10 @@ gulp.task('build:html', () => {
     }
     gulp.src('src/templates/index.html')
         .pipe(template(data))
+        .pipe(inline({
+            base: 'src/',
+            disabledTypes: ['css', 'img', 'js'], // Only inline svg files
+        }))
         .pipe(htmlmin({
             collapseWhitespace: true,
             conservativeCollapse: true

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "gulp-clean-css": "^2.0.12",
     "gulp-concat": "^2.6.0",
     "gulp-htmlmin": "^3.0.0",
+    "gulp-inline": "^0.1.3",
     "gulp-sass": "^3.0.0",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-template": "^4.0.0",

--- a/src/img/location-pin.svg
+++ b/src/img/location-pin.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+<svg xmlns="http://www.w3.org/2000/svg"
 	 width="466.583" height="466.582" viewBox="0 0 466.583 466.582">
 <g>
 	<path d="M233.292,0c-85.1,0-154.334,69.234-154.334,154.333c0,34.275,21.887,90.155,66.908,170.834

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -70,7 +70,7 @@
           <%= assetPath %>/img/woods.jpg
         ">
     <div class="col-md-7">
-      <img src="<%= assetPath %>/img/wdots_circle_big.svg" class="logo">
+      <img src="/img/wdots_circle_big.svg" class="logo">
       <h1>Web Devs of the Shire</h1>
       <h3>Join our monthly meetup for a drink, discussion and development.</h3>
     </div>
@@ -91,7 +91,7 @@
       </div><div class="next-meetup__where-and-when">
         <h4>Thursday 22nd September</h4>
         <h4>18:45 - 21:00</h4>
-        <h4><img src="<%= assetPath %>/img/location-pin.svg" class="icon">ProProcure, Europa Court, Marsham Way, Gerrards Cross, Buckinghamshire, SL9 8BQ</h4>
+        <h4><img src="/img/location-pin.svg" class="icon">ProProcure, Europa Court, Marsham Way, Gerrards Cross, Buckinghamshire, SL9 8BQ</h4>
         <span class="addtocalendar atc-style-blue socialButton">
           <var class="atc_event">
               <var class="atc_date_start">2016-09-22 18:45:00</var>
@@ -129,19 +129,19 @@
   <section class="row section">
     <h2 class="section__title">Why Is This Meetup Super Cool?</h2>
     <div class="col-md-4 feature reason">
-      <img src="<%= assetPath %>/img/smile.svg" class="reason-img">
+      <img src="/img/smile.svg" class="reason-img">
       <h3>Great People</h3>
       <p>Our meetup spans across all branches of the Web with Developers, Designers and everything else 'techy'
         in-between.</p>
     </div>
     <div class="col-md-4 feature reason">
-      <img src="<%= assetPath %>/img/chat.svg" class="reason-img">
+      <img src="/img/chat.svg" class="reason-img">
       <h3>Range of Topics</h3>
       <p>With a vast range of sources to draw from, each month different discussions and our very own 'stand-up' takes
         place spanning languages, projects and learning.</p>
     </div>
     <div class="col-md-4 feature reason">
-      <img src="<%= assetPath %>/img/compass.svg" class="reason-img">
+      <img src="/img/compass.svg" class="reason-img">
       <h3>Local to you</h3>
       <p>Meet the people attending this event from around Hertfordshire and Buckinghamshire. This will be a great
         opportunity to meet local people from your industry.</p>
@@ -159,17 +159,17 @@
       <ul class="speaker-social">
         <li>
           <a href="https://github.com/SiAdcock" target="_blank"><img alt="Simon Adcock on github"
-                                                                       src="<%= assetPath %>/img/github.svg"
+                                                                       src="/img/github.svg"
                                                                        class="speaker-social-img"></a>
         </li>
         <li>
           <a href="https://twitter.com/siadcock" target="_blank"><img alt="Simon Adcock on Twitter"
-                                                                        src="<%= assetPath %>/img/twitter.svg"
+                                                                        src="/img/twitter.svg"
                                                                         class="speaker-social-img"></a>
         </li>
         <li>
           <a href="https://www.linkedin.com/in/sjadcock" target="_blank"><img alt="Simon Adcock on LinkedIn"
-                                                                                src="<%= assetPath %>/img/linked_in.svg"
+                                                                                src="/img/linked_in.svg"
                                                                                 class="speaker-social-img"></a>
         </li>
       </ul>
@@ -181,12 +181,12 @@
       <ul class="speaker-social">
         <li>
           <a href="https://github.com/matt-platts" target="_blank"><img alt="Matt Platts on github"
-                                                                          src="<%= assetPath %>/img/github.svg"
+                                                                          src="/img/github.svg"
                                                                           class="speaker-social-img"></a>
         </li>
         <li>
           <a href="https://www.linkedin.com/in/mattplatts" target="_blank"><img alt="Matt Platts on LinkedIn"
-                                                                                  src="<%= assetPath %>/img/linked_in.svg"
+                                                                                  src="/img/linked_in.svg"
                                                                                   class="speaker-social-img"></a>
         </li>
       </ul>
@@ -198,17 +198,17 @@
       <ul class="speaker-social">
         <li>
           <a href="https://github.com/jimmynames" target="_blank"><img alt="Jimmy Names on github"
-                                                                         src="<%= assetPath %>/img/github.svg"
+                                                                         src="/img/github.svg"
                                                                          class="speaker-social-img"></a>
         </li>
         <li>
           <a href="https://twitter.com/namescodes" target="_blank"><img alt="Jimmy Names on Twitter"
-                                                                          src="<%= assetPath %>/img/twitter.svg"
+                                                                          src="/img/twitter.svg"
                                                                           class="speaker-social-img"></a>
         </li>
         <li>
           <a href="https://www.linkedin.com/in/jimmynames" target="_blank"><img alt="Jimmy Names on LinkedIn"
-                                                                                  src="<%= assetPath %>/img/linked_in.svg"
+                                                                                  src="/img/linked_in.svg"
                                                                                   class="speaker-social-img"></a>
         </li>
       </ul>
@@ -220,17 +220,17 @@
       <ul class="speaker-social">
         <li>
           <a href="https://github.com/Jameskmonger" target="_blank"><img alt="James Monger on github"
-                                                                           src="<%= assetPath %>/img/github.svg"
+                                                                           src="/img/github.svg"
                                                                            class="speaker-social-img"></a>
         </li>
         <li>
           <a href="https://twitter.com/jameskmonger" target="_blank"><img alt="James Monger on Twitter"
-                                                                            src="<%= assetPath %>/img/twitter.svg"
+                                                                            src="/img/twitter.svg"
                                                                             class="speaker-social-img"></a>
         </li>
           <li>
           <a href="https://www.linkedin.com/in/james-monger-20740b79" target="_blank"><img
-          alt="James Monger on LinkedIn" src="<%= assetPath %>/img/linked_in.svg" class="speaker-social-img"></a>
+          alt="James Monger on LinkedIn" src="/img/linked_in.svg" class="speaker-social-img"></a>
         </li>
       </ul>
     </div>
@@ -240,11 +240,11 @@
       <p>Sir JS</p>
       <ul class="speaker-social">
         <li>
-          <a href="#" target="_blank"><img alt="Steve Knight on github" src="<%= assetPath %>/img/github.svg"
+          <a href="#" target="_blank"><img alt="Steve Knight on github" src="/img/github.svg"
                                              class="speaker-social-img"></a>
         </li>
         <li>
-          <a href="#" target="_blank"><img alt="Steve Knight on LinkedIn" src="<%= assetPath %>/img/linked_in.svg"
+          <a href="#" target="_blank"><img alt="Steve Knight on LinkedIn" src="/img/linked_in.svg"
                                              class="speaker-social-img"></a>
         </li>
       </ul>
@@ -256,17 +256,17 @@
       <ul class="speaker-social">
         <li>
           <a href="https://github.com/lehanism" target="_blank"><img alt="Luke Lehane on github"
-                                                                       src="<%= assetPath %>/img/github.svg"
+                                                                       src="/img/github.svg"
                                                                        class="speaker-social-img"></a>
         </li>
         <li>
           <a href="https://twitter.com/lehanism" target="_blank"><img alt="Luke Lehane on Twitter"
-                                                                        src="<%= assetPath %>/img/twitter.svg"
+                                                                        src="/img/twitter.svg"
                                                                         class="speaker-social-img"></a>
         </li>
         <li>
           <a href="https://www.linkedin.com/in/lukelehane" target="_blank"><img alt="Luke Lehane on LinkedIn"
-                                                                                  src="<%= assetPath %>/img/linked_in.svg"
+                                                                                  src="/img/linked_in.svg"
                                                                                   class="speaker-social-img"></a>
         </li>
       </ul>
@@ -278,12 +278,12 @@
       <ul class="speaker-social">
         <li>
           <a href="https://github.com/BartNowak" target="_blank"><img alt="Bart Nowak on github"
-                                                                        src="<%= assetPath %>/img/github.svg"
+                                                                        src="/img/github.svg"
                                                                         class="speaker-social-img"></a>
         </li>
         <li>
           <a href="https://www.linkedin.com/in/bart-nowak-205b3959" target="_blank"><img alt="Bart Nowak on LinkedIn"
-                                                                                           src="<%= assetPath %>/img/linked_in.svg"
+                                                                                           src="/img/linked_in.svg"
                                                                                            class="speaker-social-img"></a>
         </li>
       </ul>
@@ -295,7 +295,7 @@
       <ul class="speaker-social">
         <li>
           <a href="https://github.com/jamesrichford" target="_blank"><img alt="James Richford on github"
-                                                                            src="<%= assetPath %>/img/github.svg"
+                                                                            src="/img/github.svg"
                                                                             class="speaker-social-img"></a>
         </li>
       </ul>
@@ -340,10 +340,10 @@
 
   <div class="row footer-credit">
     <div class="col-md-6 col-sm-6">
-      <img src="<%= assetPath %>/img/wdots_rectangle_big.svg" class="banner-logo" alt="banner logo"/>
+      <img src="/img/wdots_rectangle_big.svg" class="banner-logo" alt="banner logo"/>
     </div>
     <div class="col-md-6 col-sm-6 scrollToTop footer-arrow">
-      <img src="<%= assetPath %>/img/up-arrow.svg" class="footer-arrow-img">
+      <img src="/img/up-arrow.svg" class="footer-arrow-img">
     </div>
   </div>
 </div>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -158,19 +158,16 @@
       <p>Internet Wizard</p>
       <ul class="speaker-social">
         <li>
-          <a href="https://github.com/SiAdcock" target="_blank"><img alt="Simon Adcock on github"
-                                                                       src="/img/github.svg"
-                                                                       class="speaker-social-img"></a>
+          <a href="https://github.com/SiAdcock" target="_blank"><img
+            role="img" aria-label="Simon Adcock on github" src="/img/github.svg" class="speaker-social-img"></a>
         </li>
         <li>
-          <a href="https://twitter.com/siadcock" target="_blank"><img alt="Simon Adcock on Twitter"
-                                                                        src="/img/twitter.svg"
-                                                                        class="speaker-social-img"></a>
+          <a href="https://twitter.com/siadcock" target="_blank"><img
+            role="img" aria-label="Simon Adcock on Twitter" src="/img/twitter.svg" class="speaker-social-img"></a>
         </li>
         <li>
-          <a href="https://www.linkedin.com/in/sjadcock" target="_blank"><img alt="Simon Adcock on LinkedIn"
-                                                                                src="/img/linked_in.svg"
-                                                                                class="speaker-social-img"></a>
+          <a href="https://www.linkedin.com/in/sjadcock" target="_blank"><img
+            role="img" aria-label="Simon Adcock on LinkedIn" src="/img/linked_in.svg" class="speaker-social-img"></a>
         </li>
       </ul>
     </div>
@@ -180,14 +177,12 @@
       <p>Pearl Diver</p>
       <ul class="speaker-social">
         <li>
-          <a href="https://github.com/matt-platts" target="_blank"><img alt="Matt Platts on github"
-                                                                          src="/img/github.svg"
-                                                                          class="speaker-social-img"></a>
+          <a href="https://github.com/matt-platts" target="_blank"><img
+            role="img" aria-label="Matt Platts on github" src="/img/github.svg" class="speaker-social-img"></a>
         </li>
         <li>
-          <a href="https://www.linkedin.com/in/mattplatts" target="_blank"><img alt="Matt Platts on LinkedIn"
-                                                                                  src="/img/linked_in.svg"
-                                                                                  class="speaker-social-img"></a>
+          <a href="https://www.linkedin.com/in/mattplatts" target="_blank"><img
+            role="img" aria-label="Matt Platts on LinkedIn" src="/img/linked_in.svg" class="speaker-social-img"></a>
         </li>
       </ul>
     </div>
@@ -197,19 +192,16 @@
       <p>Dev Padewan</p>
       <ul class="speaker-social">
         <li>
-          <a href="https://github.com/jimmynames" target="_blank"><img alt="Jimmy Names on github"
-                                                                         src="/img/github.svg"
-                                                                         class="speaker-social-img"></a>
+          <a href="https://github.com/jimmynames" target="_blank"><img
+            role="img" aria-label="Jimmy Names on github" src="/img/github.svg" class="speaker-social-img"></a>
         </li>
         <li>
-          <a href="https://twitter.com/namescodes" target="_blank"><img alt="Jimmy Names on Twitter"
-                                                                          src="/img/twitter.svg"
-                                                                          class="speaker-social-img"></a>
+          <a href="https://twitter.com/namescodes" target="_blank"><img
+            role="img" aria-label="Jimmy Names on Twitter" src="/img/twitter.svg" class="speaker-social-img"></a>
         </li>
         <li>
-          <a href="https://www.linkedin.com/in/jimmynames" target="_blank"><img alt="Jimmy Names on LinkedIn"
-                                                                                  src="/img/linked_in.svg"
-                                                                                  class="speaker-social-img"></a>
+          <a href="https://www.linkedin.com/in/jimmynames" target="_blank"><img
+            role="img" aria-label="Jimmy Names on LinkedIn" src="/img/linked_in.svg" class="speaker-social-img"></a>
         </li>
       </ul>
     </div>
@@ -219,18 +211,16 @@
       <p>JS Master</p>
       <ul class="speaker-social">
         <li>
-          <a href="https://github.com/Jameskmonger" target="_blank"><img alt="James Monger on github"
-                                                                           src="/img/github.svg"
-                                                                           class="speaker-social-img"></a>
+          <a href="https://github.com/Jameskmonger" target="_blank"><img
+            role="img" aria-label="James Monger on github" src="/img/github.svg" class="speaker-social-img"></a>
         </li>
         <li>
-          <a href="https://twitter.com/jameskmonger" target="_blank"><img alt="James Monger on Twitter"
-                                                                            src="/img/twitter.svg"
-                                                                            class="speaker-social-img"></a>
+          <a href="https://twitter.com/jameskmonger" target="_blank"><img
+            role="img" aria-label="James Monger on Twitter" src="/img/twitter.svg" class="speaker-social-img"></a>
         </li>
           <li>
           <a href="https://www.linkedin.com/in/james-monger-20740b79" target="_blank"><img
-          alt="James Monger on LinkedIn" src="/img/linked_in.svg" class="speaker-social-img"></a>
+            role="img" aria-label="James Monger on LinkedIn" src="/img/linked_in.svg" class="speaker-social-img"></a>
         </li>
       </ul>
     </div>
@@ -240,12 +230,12 @@
       <p>Sir JS</p>
       <ul class="speaker-social">
         <li>
-          <a href="#" target="_blank"><img alt="Steve Knight on github" src="/img/github.svg"
-                                             class="speaker-social-img"></a>
+          <a href="#" target="_blank"><img
+            role="img" aria-label="Steve Knight on github" src="/img/github.svg" class="speaker-social-img"></a>
         </li>
         <li>
-          <a href="#" target="_blank"><img alt="Steve Knight on LinkedIn" src="/img/linked_in.svg"
-                                             class="speaker-social-img"></a>
+          <a href="#" target="_blank"><img
+            role="img" aria-label="Steve Knight on LinkedIn" src="/img/linked_in.svg" class="speaker-social-img"></a>
         </li>
       </ul>
     </div>
@@ -255,19 +245,16 @@
       <p>Pixel Perfectionist</p>
       <ul class="speaker-social">
         <li>
-          <a href="https://github.com/lehanism" target="_blank"><img alt="Luke Lehane on github"
-                                                                       src="/img/github.svg"
-                                                                       class="speaker-social-img"></a>
+          <a href="https://github.com/lehanism" target="_blank"><img
+            role="img" aria-label="Luke Lehane on github" src="/img/github.svg" class="speaker-social-img"></a>
         </li>
         <li>
-          <a href="https://twitter.com/lehanism" target="_blank"><img alt="Luke Lehane on Twitter"
-                                                                        src="/img/twitter.svg"
-                                                                        class="speaker-social-img"></a>
+          <a href="https://twitter.com/lehanism" target="_blank"><img
+            role="img" aria-label="Luke Lehane on Twitter" src="/img/twitter.svg" class="speaker-social-img"></a>
         </li>
         <li>
-          <a href="https://www.linkedin.com/in/lukelehane" target="_blank"><img alt="Luke Lehane on LinkedIn"
-                                                                                  src="/img/linked_in.svg"
-                                                                                  class="speaker-social-img"></a>
+          <a href="https://www.linkedin.com/in/lukelehane" target="_blank"><img
+            role="img" aria-label="Luke Lehane on LinkedIn" src="/img/linked_in.svg" class="speaker-social-img"></a>
         </li>
       </ul>
     </div>
@@ -277,14 +264,12 @@
       <p>Design Lord</p>
       <ul class="speaker-social">
         <li>
-          <a href="https://github.com/BartNowak" target="_blank"><img alt="Bart Nowak on github"
-                                                                        src="/img/github.svg"
-                                                                        class="speaker-social-img"></a>
+          <a href="https://github.com/BartNowak" target="_blank"><img
+            role="img" aria-label="Bart Nowak on github" src="/img/github.svg" class="speaker-social-img"></a>
         </li>
         <li>
-          <a href="https://www.linkedin.com/in/bart-nowak-205b3959" target="_blank"><img alt="Bart Nowak on LinkedIn"
-                                                                                           src="/img/linked_in.svg"
-                                                                                           class="speaker-social-img"></a>
+          <a href="https://www.linkedin.com/in/bart-nowak-205b3959" target="_blank"><img
+            role="img" aria-label="Bart Nowak on LinkedIn" src="/img/linked_in.svg" class="speaker-social-img"></a>
         </li>
       </ul>
     </div>
@@ -294,9 +279,8 @@
       <p>Shiny Grasshopper</p>
       <ul class="speaker-social">
         <li>
-          <a href="https://github.com/jamesrichford" target="_blank"><img alt="James Richford on github"
-                                                                            src="/img/github.svg"
-                                                                            class="speaker-social-img"></a>
+          <a href="https://github.com/jamesrichford" target="_blank"><img
+            role="img" aria-label="James Richford on github" src="/img/github.svg" class="speaker-social-img"></a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
# What does this change?

- Uses [`gulp-inline`](https://github.com/ashaffer/gulp-inline/) to copy the content of SVGs directly into the page markup at build time
- Updated the `alt` attribute, which I believe is not valid on SVGs, to `aria-label`. I have also added `role="img"` to these elements.

# What are the benefits?

Inlining SVG markup into the page saves the client from making external requests for the images, theoretically improving render performance.

# Further reading

- http://stackoverflow.com/questions/4697100/accessibility-recommended-alt-text-convention-for-svg-and-mathml
- https://www.w3.org/TR/wai-aria/roles#img
- https://www.w3.org/TR/wai-aria/states_and_properties#aria-label
