### PR TITLE
Added alt="" attributes to content/hero <img>'s

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -60,6 +60,7 @@
   <div class="row hero-header" id="home">
     <img src="<%= assetPath %>/img/woods.jpg"
          class="hero-header__background"
+         role="presentation" alt=""
          sizes="100vw"
          srcset="
           <%= assetPath %>/img/woods-480.jpg 480w,
@@ -128,19 +129,19 @@
   <section class="row section">
     <h2 class="section__title">Why Is This Meetup Super Cool?</h2>
     <div class="col-md-4 feature reason">
-      <img src="/img/smile.svg" class="reason-img">
+      <img src="/img/smile.svg" class="reason-img" alt="Simley face icon">
       <h3>Great People</h3>
       <p>Our meetup spans across all branches of the Web with Developers, Designers and everything else 'techy'
         in-between.</p>
     </div>
     <div class="col-md-4 feature reason">
-      <img src="/img/chat.svg" class="reason-img">
+      <img src="/img/chat.svg" class="reason-img" alt="Speech bubble icon">
       <h3>Range of Topics</h3>
       <p>With a vast range of sources to draw from, each month different discussions and our very own 'stand-up' takes
         place spanning languages, projects and learning.</p>
     </div>
     <div class="col-md-4 feature reason">
-      <img src="/img/compass.svg" class="reason-img">
+      <img src="/img/compass.svg" class="reason-img" class="Compas icon">
       <h3>Local to you</h3>
       <p>Meet the people attending this event from around Hertfordshire and Buckinghamshire. This will be a great
         opportunity to meet local people from your industry.</p>
@@ -152,7 +153,7 @@
   <section class="row section speaker" id="speakers">
     <h2 class="section__title">Meet some Members</h2>
     <div class="col-md-4 col-sm-6 feature">
-      <img src="<%= assetPath %>/img/simon-130.jpg" class="speaker-img">
+      <img src="<%= assetPath %>/img/simon-130.jpg" class="speaker-img" alt="Photograph of Simon Adcock">
       <h3>Simon Adcock</h3>
       <p>Internet Wizard</p>
       <ul class="speaker-social">
@@ -171,7 +172,7 @@
       </ul>
     </div>
     <div class="col-md-4 col-sm-6 feature">
-      <img src="<%= assetPath %>/img/matt-130.jpg" class="speaker-img">
+      <img src="<%= assetPath %>/img/matt-130.jpg" class="speaker-img" alt="Photograph of Matt Platts">
       <h3>Matt Platts</h3>
       <p>Pearl Diver</p>
       <ul class="speaker-social">
@@ -186,7 +187,7 @@
       </ul>
     </div>
     <div class="col-md-4 col-sm-6 feature">
-      <img src="<%= assetPath %>/img/jimmy-130.jpg" class="speaker-img">
+      <img src="<%= assetPath %>/img/jimmy-130.jpg" class="speaker-img" alt="Photograph of Jimmy Names">
       <h3>Jimmy Names</h3>
       <p>Dev Padewan</p>
       <ul class="speaker-social">
@@ -205,7 +206,7 @@
       </ul>
     </div>
     <div class="col-md-4 col-sm-6 feature">
-      <img src="<%= assetPath %>/img/james-130.jpg" class="speaker-img">
+      <img src="<%= assetPath %>/img/james-130.jpg" class="speaker-img" alt="Photograph of James Monger">
       <h3>James Monger</h3>
       <p>JS Master</p>
       <ul class="speaker-social">
@@ -224,7 +225,7 @@
       </ul>
     </div>
     <div class="col-md-4 col-sm-6 feature">
-      <img src="<%= assetPath %>/img/steve-130.jpg" class="speaker-img">
+      <img src="<%= assetPath %>/img/steve-130.jpg" class="speaker-img" alt="Illustration of Steve Knight">
       <h3>Steve Knight</h3>
       <p>Sir JS</p>
       <ul class="speaker-social">
@@ -239,7 +240,7 @@
       </ul>
     </div>
     <div class="col-md-4 col-sm-6 feature">
-      <img src="<%= assetPath %>/img/luke-130.jpg" class="speaker-img">
+      <img src="<%= assetPath %>/img/luke-130.jpg" class="speaker-img" alt="Photograph of Luke Lehane">
       <h3>Luke Lehane</h3>
       <p>Pixel Perfectionist</p>
       <ul class="speaker-social">
@@ -258,7 +259,7 @@
       </ul>
     </div>
     <div class="col-md-4 col-sm-6 feature">
-      <img src="<%= assetPath %>/img/bart-130.jpg" class="speaker-img">
+      <img src="<%= assetPath %>/img/bart-130.jpg" class="speaker-img" alt="Photograph of Bart Nowak">
       <h3>Bart Nowak</h3>
       <p>Design Lord</p>
       <ul class="speaker-social">
@@ -273,7 +274,7 @@
       </ul>
     </div>
     <div class="col-md-4 col-sm-6 feature">
-      <img src="<%= assetPath %>/img/james-r-130.jpg" class="speaker-img">
+      <img src="<%= assetPath %>/img/james-r-130.jpg" class="speaker-img" alt="Photograph of James Richford">
       <h3>James Richford</h3>
       <p>Shiny Grasshopper</p>
       <ul class="speaker-social">

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -129,7 +129,7 @@
   <section class="row section">
     <h2 class="section__title">Why Is This Meetup Super Cool?</h2>
     <div class="col-md-4 feature reason">
-      <img src="/img/smile.svg" class="reason-img" alt="Simley face icon">
+      <img src="/img/smile.svg" class="reason-img" alt="Smiley face icon">
       <h3>Great People</h3>
       <p>Our meetup spans across all branches of the Web with Developers, Designers and everything else 'techy'
         in-between.</p>
@@ -141,7 +141,7 @@
         place spanning languages, projects and learning.</p>
     </div>
     <div class="col-md-4 feature reason">
-      <img src="/img/compass.svg" class="reason-img" class="Compas icon">
+      <img src="/img/compass.svg" class="reason-img" class="Compass icon">
       <h3>Local to you</h3>
       <p>Meet the people attending this event from around Hertfordshire and Buckinghamshire. This will be a great
         opportunity to meet local people from your industry.</p>


### PR DESCRIPTION
Pull request for: #79 

# What does this change?

I've added `role="presentation" alt=""` to the hero image, as it's there for design, so has no meaningful existence as content.. I've added `alt` attributes to the images of everyones avatars.

# Why?

Because accessibility matters! Without `alt` attributes, I believe some screen readers will read the `src` which is less than helpful. 👍 