### PR TITLE
Defer execution of JavaScript

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -329,10 +329,11 @@
 <!-- End: Footer -->
 
 <script src="<%= vendorPaths.jquery %>" integrity="sha256-cCueBR6CsyA4/9szpPfrX3s49M9vUU5BgtiJj06wt/s="
-        crossorigin="anonymous"></script>
-<script src="<%= vendorPaths.jqueryEasing %>"></script>
-<script src="<%= vendorPaths.jqueryVisible %>"></script>
-<script src="<%= vendorPaths.addToCalendarJs %>"></script>
-<script src="<%= assetPath %>/js/main.js"></script>
+        crossorigin="anonymous" defer></script>
+<script src="<%= vendorPaths.jqueryEasing %>" defer></script>
+<script src="<%= vendorPaths.jqueryVisible %>" defer></script>
+<script src="<%= vendorPaths.addToCalendarJs %>" defer></script>
+<script src="<%= assetPath %>/js/main.js" defer></script>
+
 </body>
 </html>


### PR DESCRIPTION
# What does this change?

All our JavaScript is effectively non-critical, affecting only content below the fold. This change defers the execution of all JavaScript files, removing them from the critical path.

# What are the benefits?

By removing the JavaScript from the critical path:

- we reduce the critical path length by one
- we reduce the number of critical bytes by 71.4KB Gzipped 
- we shorten the time to interactive (tti). In throttled tests on Regular 3G (100ms, 750kb/s, 250kb/s) this improved the time to interactive by ~1000ms.

There was no notable change to DOM Content Loaded or Load events.