### PR TITLE
unpkg all the things

### DIFF
--- a/tools/tasks/html.js
+++ b/tools/tasks/html.js
@@ -24,13 +24,13 @@ module.exports = function html() {
         };
     } else {
         data.vendorPaths = {
-            jquery: '//code.jquery.com/jquery-3.1.0.min.js',
-            jqueryEasing: '//cdnjs.cloudflare.com/ajax/libs/jquery-easing/1.3/jquery.easing.min.js',
+            jquery: '//unpkg.com/jquery@3.1.0/dist/jquery.min.js',
+            jqueryEasing: '//unpkg.com/jquery-easing@0.0.1/dist/jquery.easing.1.3.umd.min.js',
             jqueryVisible: '//cdnjs.cloudflare.com/ajax/libs/jquery-visible/1.2.0/jquery.visible.min.js',
-            bootstrap: '//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css',
+            bootstrap: '//unpkg.com/bootstrap@3.3.6/dist/css/bootstrap.min.css',
             addToCalendarCss: '//addtocalendar.com/atc/1.5/atc-base.css',
-            html5Shiv: '//oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js',
-            respond: '//oss.maxcdn.com/respond/1.4.2/respond.min.js',
+            html5Shiv: '//unpkg.com/html5shiv@3.7.3/dist/html5shiv.min.js',
+            respond: '//unpkg.com/respond.js@1.4.2/dest/respond.min.js',
             addToCalendarJs: '//addtocalendar.com/atc/1.5/atc.min.js'
         };
     }

--- a/tools/tasks/html.js
+++ b/tools/tasks/html.js
@@ -17,7 +17,6 @@ module.exports = function html() {
             jqueryEasing: 'build/js/vendor/jquery.easing.min.js',
             jqueryVisible: 'build/js/vendor/jquery.visible.min.js',
             bootstrap: 'build/css/vendor/bootstrap.min.css',
-            addToCalendarCss: 'build/css/vendor/atc-base.css',
             html5Shiv: 'build/js/vendor/html5shiv.min.js',
             respond: 'build/js/vendor/respond.min.js',
             addToCalendarJs: 'build/js/vendor/atc.min.js'
@@ -28,7 +27,6 @@ module.exports = function html() {
             jqueryEasing: '//unpkg.com/jquery-easing@0.0.1/dist/jquery.easing.1.3.umd.min.js',
             jqueryVisible: '//cdnjs.cloudflare.com/ajax/libs/jquery-visible/1.2.0/jquery.visible.min.js',
             bootstrap: '//unpkg.com/bootstrap@3.3.6/dist/css/bootstrap.min.css',
-            addToCalendarCss: '//addtocalendar.com/atc/1.5/atc-base.css',
             html5Shiv: '//unpkg.com/html5shiv@3.7.3/dist/html5shiv.min.js',
             respond: '//unpkg.com/respond.js@1.4.2/dest/respond.min.js',
             addToCalendarJs: '//addtocalendar.com/atc/1.5/atc.min.js'


### PR DESCRIPTION
# What does this change?

Consistently uses the same CDN ([unpkg.com](https://unpkg.com)) for (nearly) all our third party dependencies

# What are the benefits?

As @chrisgeary92 says in #73:

> keeps the number of hosts the browser has to resolve to a minimum, less certificates need parsing, and less DNS lookups have to be made if everything comes from the same place :)

Also the version of `jquery-easing` on unpkg is more heavily minified than the version on Cloudflare, saving a few bytes