### PR TITLE
Register pre-cache service worker

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 src/js/vendor/
 build/
+service-worker.js

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ jspm_packages
 
 build
 /index.html
+service-worker.js

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,4 +1,5 @@
 const gulp = require('gulp');
+const runSequence = require('run-sequence');
 const serve = require('./tools/tasks/serve');
 const clean = require('./tools/tasks/clean');
 const js = require('./tools/tasks/js');
@@ -6,12 +7,28 @@ const css = require('./tools/tasks/css');
 const html = require('./tools/tasks/html');
 const fonts = require('./tools/tasks/fonts');
 const images = require('./tools/tasks/images');
+const generateServiceWorker = require('./tools/tasks/generate-service-worker');
 
-gulp.task('default', ['serve']);
-gulp.task('serve', ['build'], serve);
-gulp.task('build', ['clean', 'build:js', 'build:css', 'build:fonts', 'build:images'], html);
+gulp.task('default', function (done) {
+    runSequence('build', 'serve', done);
+});
+gulp.task('build', function (done) {
+    runSequence(
+        'clean',
+        'build:js',
+        'build:css',
+        'build:fonts',
+        'build:images',
+        'generate-service-worker',
+        'build:html',
+        done
+    );
+});
+gulp.task('serve', serve);
 gulp.task('clean', clean);
 gulp.task('build:js', js);
 gulp.task('build:css', css);
 gulp.task('build:fonts', fonts);
+gulp.task('build:html', html);
 gulp.task('build:images', images);
+gulp.task('generate-service-worker', generateServiceWorker);

--- a/package.json
+++ b/package.json
@@ -42,9 +42,12 @@
     "gulp-sourcemaps": "^1.6.0",
     "gulp-template": "^4.0.0",
     "gulp-uglify": "^2.0.0",
+    "gulp-util": "^3.0.8",
     "megalog": "^0.1.0",
     "mkdirp": "^0.5.1",
     "pre-commit": "^1.1.3",
-    "shelljs": "^0.7.3"
+    "run-sequence": "^1.2.2",
+    "shelljs": "^0.7.3",
+    "sw-precache": "^4.3.0"
   }
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -26,7 +26,7 @@ cd ..
 rm -rf out/* || exit 0
 
 # Copy servable content into out/
-cp -a build index.html out/
+cp -a build index.html service-worker.js out/
 
 # Now let's go have some fun with the cloned repo
 cd out

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -8,6 +8,11 @@
         content="WDOTS is a web developer meetup based in Gerrards Cross, Buckinghamshire. Join us for all things development, design and web for discussion, talks and more">
   <title>Web Devs of the Shire</title>
 
+  <script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('service-worker.js');
+    }
+  </script>
   <link href="<%= assetPath %>/img/favicon.ico" rel="shortcut icon">
   <link href="<%= vendorPaths.bootstrap %>" rel="stylesheet"
         integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">

--- a/tools/tasks/css.js
+++ b/tools/tasks/css.js
@@ -12,7 +12,8 @@ module.exports = function css() {
         gulp.src(['src/css/vendor/*.css', 'src/css/vendor/*.map'])
             .pipe(gulp.dest('build/css/vendor'));
     }
-    gulp.src('src/css/style.scss')
+
+    return gulp.src('src/css/style.scss')
         .pipe(preprocess())
         .pipe(sourcemaps.init())
         .pipe(sass())

--- a/tools/tasks/css.js
+++ b/tools/tasks/css.js
@@ -7,7 +7,7 @@ const sourcemaps = require('gulp-sourcemaps');
 const browserSync = require('./helpers/browserSync');
 const isDev = require('./helpers/isDev');
 
-module.exports = function css(cb) {
+module.exports = function css() {
     if (isDev()) {
         gulp.src(['src/css/vendor/*.css', 'src/css/vendor/*.map'])
             .pipe(gulp.dest('build/css/vendor'));
@@ -22,6 +22,5 @@ module.exports = function css(cb) {
             sourceMappingURLPrefix: isDev() ? '' : '/build/css'
         }))
         .pipe(browserSync.stream())
-        .pipe(gulp.dest('build/css/'))
-        .on('end', cb);
+        .pipe(gulp.dest('build/css/'));
 };

--- a/tools/tasks/generate-service-worker.js
+++ b/tools/tasks/generate-service-worker.js
@@ -1,0 +1,6 @@
+const writeServiceWorkerFile = require('./helpers/write-service-worker-file');
+const isDev = require('./helpers/isDev');
+
+module.exports = function (callback) {
+    writeServiceWorkerFile(!isDev(), callback);
+};

--- a/tools/tasks/helpers/write-service-worker-file.js
+++ b/tools/tasks/helpers/write-service-worker-file.js
@@ -1,0 +1,17 @@
+const { log } = require('gulp-util');
+const swPrecache = require('sw-precache');
+const { name } = require('../../../package.json');
+
+module.exports = function writeServiceWorkerFile(handleFetch, callback) {
+    const config = {
+        cacheId: name,
+        handleFetch,
+        logger: log,
+        staticFileGlobs: [
+            'build/img/**.*',
+            'build/js/**.js'
+        ],
+    };
+
+    swPrecache.write('service-worker.js', config, callback);
+};

--- a/tools/tasks/html.js
+++ b/tools/tasks/html.js
@@ -32,7 +32,8 @@ module.exports = function html() {
             addToCalendarJs: '//addtocalendar.com/atc/1.5/atc.min.js'
         };
     }
-    gulp.src('src/templates/index.html')
+
+    return gulp.src('src/templates/index.html')
         .pipe(template(data))
         .pipe(inline({
             base: 'build/',

--- a/tools/tasks/images.js
+++ b/tools/tasks/images.js
@@ -1,7 +1,6 @@
 const shell = require('shelljs');
 
-module.exports = function images(cb) {
+module.exports = function images() {
     shell.mkdir('-p', 'build/img/');
     shell.cp('src/img/*', 'build/img/');
-    cb();
 };

--- a/tools/tasks/js.js
+++ b/tools/tasks/js.js
@@ -10,7 +10,8 @@ module.exports = function js() {
         gulp.src('src/js/vendor/*.js')
             .pipe(gulp.dest('build/js/vendor'));
     }
-    gulp.src('src/js/*.js')
+
+    return gulp.src('src/js/*.js')
         .pipe(sourcemaps.init())
         .pipe(uglify({ mangle: false }))
         .pipe(concat('main.js'))


### PR DESCRIPTION
Take 2: ~#98~

# What does this change?

Uses [`sw-precache`](https://github.com/GoogleChrome/sw-precache) to pre-cache image and JS assets. 

When the page first loads, it registers a service worker that intercepts network requests for image and JS files and serves them from the browser cache if possible.

The service worker first ensures there have been no changes to the files before intercepting requests, so the client always requests fresh assets if they have changed since the last time they visited.

In order to make this work correctly, I have also installed the [`run-sequence`](https://github.com/OverZealous/run-sequence) Gulp plugin that can run Gulp tasks synchronously.

# What are the benefits?

It is quicker to load files from the cache rather than the network. 

This is also a step along the path towards making our site run offline (#85).