### PR TITLE
Update website URL within README to be https://

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/WDOTS/wdots.github.io.svg)](https://travis-ci.org/WDOTS/wdots.github.io)
 
-[http://wdots.github.io/](http://wdots.github.io/)
+[https://wdots.github.io/](https://wdots.github.io/)
 
 ## Contribute
 


### PR DESCRIPTION
I've updated the URL to WDOTS website in the README to start with https:// now that the site is https:// .. Trivial, but prevents an insecure redirect from http:// to https://