### PR TITLE
Add background-colour #234823 to hero-header

### DIFF
--- a/src/css/modules/_hero-header.scss
+++ b/src/css/modules/_hero-header.scss
@@ -4,6 +4,7 @@
     min-height: 600px;
     padding: 5em;
     color: #ffffff;
+    background-color: #234823;
 }
 
 .hero-header__background {


### PR DESCRIPTION
See: #111 

# What's changed?

I've updated the background colour for the `.hero-header` (main image with the woods) to be `#234823`.

# Why?

If the image hasn't loaded in, or the user has disabled images, the white text would still be readable as it currently is not. 