### PR TITLE
Fade without jQuery animate

### DIFF
--- a/src/css/components/_reason.scss
+++ b/src/css/components/_reason.scss
@@ -1,9 +1,17 @@
 .reason {
     opacity: 0;
     position: relative;
+    top: 0;
     padding: 20px;
     margin-top: 30px;
     vertical-align: top;
+}
+
+.reason--visible {
+    opacity: 1;
+    top: 20px;
+    transition: opacity .6s, top .6s;
+    transition-delay: .6s;
 }
 
 @media (min-width: $width-ipad-landscape-min) {

--- a/src/css/modules/_footer.scss
+++ b/src/css/modules/_footer.scss
@@ -32,4 +32,10 @@
     width: 48px;
     opacity: 0;
     cursor: pointer;
+    transition: .6s opacity;
+    transition-delay: .6s;
+}
+
+.footer__arrow__img--visible {
+    opacity: .7;
 }

--- a/src/js/bind-scroll-events.js
+++ b/src/js/bind-scroll-events.js
@@ -1,0 +1,13 @@
+$(function () {
+    $('.page-scroll').on('click', function (event) {
+        var el = $($(this).attr('href'))[0];
+
+        event.preventDefault();
+        scrollIt(el, 1200, 'easeInOutQuad');
+    });
+
+    $('.js-footer-arrow').on('click', function () {
+        // TODO: replace with scrollIt
+        $('html, body').animate({ scrollTop: 0 }, 800);
+    });
+});

--- a/src/js/scrolling-nav.js
+++ b/src/js/scrolling-nav.js
@@ -1,8 +1,0 @@
-$(function () {
-    $('.page-scroll').bind('click', function (event) {
-        var el = $($(this).attr('href'))[0];
-
-        event.preventDefault();
-        scrollIt(el, 1200, 'easeInOutQuad');
-    });
-});

--- a/src/js/super-cool-fade.js
+++ b/src/js/super-cool-fade.js
@@ -16,10 +16,6 @@ $(document).ready(function () {
         opacity: 1,
         top: '+=20'
     };
-    var scrollToTop = function () {
-        $('html, body').animate({ scrollTop: 0 }, 800);
-        return false;
-    };
     $(document).on('scroll', function handler() {
         fadeIntoBeing($arrow, fade, function callback() {
             $(document).off('scroll', handler);
@@ -30,6 +26,4 @@ $(document).ready(function () {
             $(document).off('scroll', handler);
         });
     });
-
-    $arrow.click(scrollToTop);
 });

--- a/src/js/super-cool-fade.js
+++ b/src/js/super-cool-fade.js
@@ -1,31 +1,18 @@
-function fadeIntoBeing(selection, animation, callback) {
-    if (selection.visible(true)) {
-        selection.delay(600).animate(animation);
-        callback();
-    }
-}
-
-function classyFade(selection, classy, callback) {
-    if (selection.visible(true)) {
-        selection.addClass(classy);
-        callback();
-    }
-}
-
 $(document).ready(function () {
-    var $arrow = $('.js-footer-arrow');
-    var $reasons = $('.reason');
-    var upAndEase = {
-        opacity: 1,
-        top: '+=20'
-    };
+    function classyFade(selection, classy, callback) {
+        if (selection.visible(true)) {
+            selection.addClass(classy);
+            callback();
+        }
+    }
+
     $(document).on('scroll', function handler() {
-        classyFade($arrow, 'footer__arrow__img--visible', function () {
+        classyFade($('.js-footer-arrow'), 'footer__arrow__img--visible', function callback() {
             $(document).off('scroll', handler);
         });
     });
     $(document).on('scroll', function handler() {
-        fadeIntoBeing($reasons, upAndEase, function callback() {
+        classyFade($('.reason'), 'reason--visible', function callback() {
             $(document).off('scroll', handler);
         });
     });

--- a/src/js/super-cool-fade.js
+++ b/src/js/super-cool-fade.js
@@ -5,19 +5,22 @@ function fadeIntoBeing(selection, animation, callback) {
     }
 }
 
+function classyFade(selection, classy, callback) {
+    if (selection.visible(true)) {
+        selection.addClass(classy);
+        callback();
+    }
+}
+
 $(document).ready(function () {
     var $arrow = $('.js-footer-arrow');
     var $reasons = $('.reason');
-    var fade = {
-        opacity: 0.7,
-        duration: 600
-    };
     var upAndEase = {
         opacity: 1,
         top: '+=20'
     };
     $(document).on('scroll', function handler() {
-        fadeIntoBeing($arrow, fade, function callback() {
+        classyFade($arrow, 'footer__arrow__img--visible', function () {
             $(document).off('scroll', handler);
         });
     });


### PR DESCRIPTION
# What does this change?

Removes a couple of calls to jQuery's `animate` method, replacing them with CSS transitions.

# What are the benefits?

- It's preferable to use standards-compliant browser features such as CSS rather than third party libraries
- Another step towards killing all jQuery (#118) 