### PR TITLE
Replace jQuery animate with scrollit

### DIFF
--- a/src/js/bind-scroll-events.js
+++ b/src/js/bind-scroll-events.js
@@ -7,7 +7,8 @@ $(function () {
     });
 
     $('.js-footer-arrow').on('click', function () {
-        // TODO: replace with scrollIt
-        $('html, body').animate({ scrollTop: 0 }, 800);
+        var header = $('.hero-header')[0];
+
+        scrollIt(header, 800, 'easeInOutQuad');
     });
 });


### PR DESCRIPTION
## What does this change?

Replaces a call to jQuery's `animate` with a call to `scrollIt`

## What is the benefit?

One less reason to continue using jQuery (#118)
