### PR TITLE
Turn off linebreak-style linting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,7 +14,8 @@
         "no-var": "off",
         "comma-dangle": "off",
         "object-shorthand": "off",
-        "import/no-extraneous-dependencies": ["error", {"devDependencies": true}]
+        "import/no-extraneous-dependencies": ["error", {"devDependencies": true}],
+        "linebreak-style": "off"
     },
     "globals": {
         "$": true,


### PR DESCRIPTION
## What does this change?

Currently `eslint-config-airbnb-base` insists on us using `LF` line endings, whereas Windows machines use `CRLF`, therefore pre-commit linting fails and Windows devs can't contribute. To fix this, Windows devs would have to delete the `wdots.github.io` repo, update their system wide line-ending setting to `LF`, re-clone the repo and then remember to restore the line-ending setting back to `CRLF` every time they wanted to make a change to this repo.

Alternatively, we ignore this lint rule and hope for the best :man_shrugging: 

## What is the benefit?

Nicer developer experience for Windows devs.
