### PR TITLE
Added width to `srcset=""` woods.jpg image

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -68,7 +68,7 @@
           <%= assetPath %>/img/woods-640.jpg 640w,
           <%= assetPath %>/img/woods-960.jpg 960w,
           <%= assetPath %>/img/woods-1280.jpg 1280w,
-          <%= assetPath %>/img/woods.jpg
+          <%= assetPath %>/img/woods.jpg 1920w
         ">
     <div class="hero-header__content">
       <img src="/img/wdots_circle_big.svg" class="hero-header__logo">


### PR DESCRIPTION
## What does this change?

Adds a width to the largest woods image used in the header in the `srcset` attribute.

## What is the benefit?

Makes the markup valid. Without the width it doesn't follow the spec completely.

## Screenshots

![screen shot 2017-04-01 at 13 47 07](https://cloud.githubusercontent.com/assets/3949335/24578851/b9ec332c-16e1-11e7-8c6b-aaf39b847c2e.png)
