### PR TITLE
Re-order SCSS properties to pass linter rules

### DIFF
--- a/src/css/base/_base.scss
+++ b/src/css/base/_base.scss
@@ -3,17 +3,17 @@
 }
 
 body {
-    font-family: 'Dosis', sans-serif;
     color: #404142;
+    font-family: 'Dosis', sans-serif;
     font-size: 16px;
     letter-spacing: .8px;
 }
 
 h1, h2, h3, h4, h5, h6 {
     font-weight: 200;
-    margin-top: 10px;
-    margin-bottom: 10px;
     line-height: 1.1;
+    margin-bottom: 10px;
+    margin-top: 10px;
 }
 
 h2 {
@@ -33,14 +33,14 @@ p {
 }
 
 ul {
+    list-style: none;
     margin: 0;
     padding: 0;
-    list-style: none;
 }
 
 a {
-    -webkit-transition: all .3s;
     -moz-transition: all .3s;
+    -webkit-transition: all .3s;
     transition: all .3s;
 }
 

--- a/src/css/base/_mixins.scss
+++ b/src/css/base/_mixins.scss
@@ -1,7 +1,7 @@
 @mixin button-context($background, $text, $border) {
     background-color: $background;
-    color: $text;
     border-color: $border;
+    color: $text;
     &:hover, &:active, &:focus {
         background-color: darken($background, 10%);
         border-color: darken($border, 10%);

--- a/src/css/components/_add-to-calendar.scss
+++ b/src/css/components/_add-to-calendar.scss
@@ -1,26 +1,26 @@
 .atc-style-green {
     .atcb-list {
-        width: 100%;
         background: #ffffff;
         border: 1px solid #bababa;
         border-radius: 2px;
         box-shadow: 0 0 5px #aaaaaa;
+        width: 100%;
     }
 
     .atcb-link {
-        border-radius: 4px;
-        padding: 15px 40px;
-        text-transform: uppercase;
-        font-weight: 600;
-        line-height: 1.3333333;
-        text-align: center;
-        white-space: nowrap;
-        vertical-align: middle;
-        touch-action: manipulation;
-        cursor: pointer;
         -webkit-user-select: none;
         border: 1px solid transparent;
-
+        border-radius: 4px;
+        cursor: pointer;
+        font-weight: 600;
+        line-height: 1.3333333;
+        padding: 15px 40px;
+        text-align: center;
+        text-transform: uppercase;
+        touch-action: manipulation;
+        vertical-align: middle;
+        white-space: nowrap;
+        
         @include button-context($button-success-background, $button-success-text, $button-success-border);
     }
 
@@ -31,11 +31,11 @@
     }
 
     .atcb-item-link {
-        font-size: .875em;
         color: #000000;
-        text-decoration: none;
+        font-size: .875em;
         outline: none;
         padding: 5px 15px;
+        text-decoration: none;
         transition: none;
 
         &:hover {

--- a/src/css/components/_button.scss
+++ b/src/css/components/_button.scss
@@ -1,28 +1,28 @@
 .button {
-    text-transform: uppercase;
-    font-weight: 600;
-    display: inline-block;
-    padding: 6px 12px;
-    margin-bottom: 0;
-    font-size: 14px;
-    line-height: 1.42857143;
-    text-align: center;
-    white-space: nowrap;
-    vertical-align: middle;
-    -ms-touch-action: manipulation;
-    touch-action: manipulation;
-    cursor: pointer;
-    -webkit-user-select: none;
     -moz-user-select: none;
+    -ms-touch-action: manipulation;
     -ms-user-select: none;
-    user-select: none;
+    -webkit-user-select: none;
     background-image: none;
     border: 1px solid transparent;
     border-radius: 4px;
+    cursor: pointer;
+    display: inline-block;
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 1.42857143;
+    margin-bottom: 0;
+    padding: 6px 12px;
+    text-align: center;
+    text-transform: uppercase;
+    touch-action: manipulation;
+    user-select: none;
+    vertical-align: middle;
+    white-space: nowrap;
 }
 .button--lg {
-    padding: 15px 40px;
     font-size: 16px;
+    padding: 15px 40px;
 }
 
 .button--success {

--- a/src/css/components/_container.scss
+++ b/src/css/components/_container.scss
@@ -1,8 +1,8 @@
 .container {
-    padding-right: 0;
-    padding-left: 0;
-    margin-right: auto;
     margin-left: auto;
+    margin-right: auto;
+    padding-left: 0;
+    padding-right: 0;
 }
 
 @media (min-width: 768px) {
@@ -24,8 +24,8 @@
 }
 
 .container-fluid {
-    padding-right: 0;
-    padding-left: 0;
-    margin-right: auto;
     margin-left: auto;
+    margin-right: auto;
+    padding-left: 0;
+    padding-right: 0;
 }

--- a/src/css/components/_icon.scss
+++ b/src/css/components/_icon.scss
@@ -1,6 +1,5 @@
-
 .icon {
-    width: 16px;
     height: 16px;
     vertical-align: top;
+    width: 16px;
 }

--- a/src/css/components/_reason.scss
+++ b/src/css/components/_reason.scss
@@ -1,9 +1,9 @@
 .reason {
+    margin-top: 30px;
     opacity: 0;
+    padding: 20px;
     position: relative;
     top: 0;
-    padding: 20px;
-    margin-top: 30px;
     vertical-align: top;
 }
 
@@ -16,12 +16,12 @@
 
 @media (min-width: $width-ipad-landscape-min) {
     .reason {
-        width: 33.33333333%;
         display: inline-block;
+        width: 33.33333333%;
     }
 }
 
 .reason__img {
-    max-width: 64px;
     max-height: 54px;
+    max-width: 64px;
 }

--- a/src/css/components/_side-menu.scss
+++ b/src/css/components/_side-menu.scss
@@ -7,8 +7,8 @@
 }
 
 .side-menu__item {
-    text-align: right;
     margin: 10px 0;
+    text-align: right;
 }
 
 .side-menu__item__title, .side-menu__item__dot {
@@ -16,32 +16,32 @@
 }
 
 .side-menu__item__title {
-    color: #ffffff;
-    text-transform: uppercase;
-    font-size: 12px;
-    background-color: #659d32;
-    padding: 3px 10px;
-    margin-right: 10px;
-    font-weight: 600;
-    border-radius: 3px;
-    -webkit-transition: -webkit-transform .2s, opacity .2s;
     -moz-transition: -moz-transform .2s, opacity .2s;
-    transition: transform .2s, opacity .2s;
+    -webkit-transition: -webkit-transform .2s, opacity .2s;
+    background-color: #659d32;
+    border-radius: 3px;
+    color: #ffffff;
+    font-size: 12px;
+    font-weight: 600;
+    margin-right: 10px;
     opacity: 0;
-
+    padding: 3px 10px;
+    text-transform: uppercase;
+    transition: transform .2s, opacity .2s;
+    
     a:hover & {
         opacity: 1;
     }
 }
 
 .side-menu__item__dot {
+    -moz-transition: all .3s;
+    -webkit-transition: all .3s;
     background-color: #659d32;
     border-radius: 2em;
     height: 10px;
-    width: 10px;
-    -webkit-transition: all .3s;
-    -moz-transition: all .3s;
     transition: all .3s;
+    width: 10px;
 
     a:hover & {
         transform: scale(1.8);

--- a/src/css/components/_social.scss
+++ b/src/css/components/_social.scss
@@ -1,17 +1,17 @@
 .social__item {
-    list-style: none;
     display: inline-block;
+    list-style: none;
     margin: 10px 5px;
 
     a {
-        text-align: center;
         display: block;
         padding: 0 10px;
+        text-align: center;
     }
 }
 
 .social__item__img {
-    width: 16px;
-    height: 16px;
     fill: #000000;
+    height: 16px;
+    width: 16px;
 }

--- a/src/css/modules/_footer.scss
+++ b/src/css/modules/_footer.scss
@@ -1,11 +1,11 @@
 .footer {
-    border-top: 1px #545454 solid;
+    align-items: center;
     background-color: #2a2a2a;
+    border-top: 1px #545454 solid;
     color: #939393;
-    padding: 20px;
     display: flex;
     flex-direction: column;
-    align-items: center;
+    padding: 20px;
 }
 
 .footer__logo, .footer__arrow {
@@ -35,12 +35,12 @@
 }
 
 .footer__arrow__img {
-    height: 32px;
-    width: 48px;
-    opacity: 0;
     cursor: pointer;
+    height: 32px;
+    opacity: 0;
     transition: .6s opacity;
     transition-delay: .6s;
+    width: 48px;
 }
 
 .footer__arrow__img--visible {

--- a/src/css/modules/_hero-header.scss
+++ b/src/css/modules/_hero-header.scss
@@ -1,18 +1,18 @@
 .hero-header {
-    position: relative;
-    overflow: hidden;
-    min-height: 600px;
-    padding: 5em;
-    color: #ffffff;
     background-color: #234823;
+    color: #ffffff;
+    min-height: 600px;
+    overflow: hidden;
+    padding: 5em;
+    position: relative;
 }
 
 .hero-header__background {
+    left: 0;
+    min-height: 100%;
+    opacity: .9;
     position: absolute;
     top: 0;
-    left: 0;
-    opacity: .9;
-    min-height: 100%;
 }
 
 .hero-header__content {
@@ -20,20 +20,20 @@
 }
 
 .hero-header__logo {
-    max-width: 180px;
     height: 180px;
+    max-width: 180px;
 }
 
 .hero-header__title {
-    margin: 1em 0 0 0;
-    font-weight: 300;
     font-size: 4em;
+    font-weight: 300;
+    margin: 1em 0 0 0;
 }
 
 .hero-header__description {
     font-weight: normal;
-    opacity: .9;
     letter-spacing: 1px;
     margin: 2em 0;
+    opacity: .9;
     text-shadow: 1px 1px #000000;
 }

--- a/src/css/modules/_join-in.scss
+++ b/src/css/modules/_join-in.scss
@@ -1,7 +1,7 @@
 .join-in {
     background-color: #c0d9af;
-    padding-top: 50px;
     padding-bottom: 75px;
+    padding-top: 50px;
 }
 
 .join-in__title {
@@ -10,10 +10,10 @@
 
 .join-in__section {
     display: inline-block;
-    width: 100%;
-    vertical-align: top;
-    padding: 2em;
     margin: 0 auto;
+    padding: 2em;
+    vertical-align: top;
+    width: 100%;
 }
 
 @media (min-width: 768px) {

--- a/src/css/modules/_next-meetup.scss
+++ b/src/css/modules/_next-meetup.scss
@@ -6,21 +6,21 @@
     height: 0;
 
     &::before {
+        background-color: #c5e3bf;
         content: '';
         display: block;
-        background-color: #c5e3bf;
         height: 20px;
     }
 }
 
 .next-meetup__banner__heading {
-    display: inline-block;
-    position: relative;
-    top: -33px;
     background-color: #ffffff;
     border: 3px dotted green;
+    display: inline-block;
     margin: 0;
     padding: 4px 48px;
+    position: relative;
+    top: -33px;
 }
 
 .next-meetup__info, .next-meetup__where-and-when {
@@ -28,8 +28,8 @@
 }
 
 .next-meetup__info {
-    text-align: left;
     margin-top: 20px;
+    text-align: left;
 
     p {
         margin: 1em 0;
@@ -37,10 +37,10 @@
 }
 
 .next-meetup__info__heading {
-    display: inline-block;
-    text-align: left;
     border-bottom: solid 3px green;
+    display: inline-block;
     line-height: 50px;
+    text-align: left;
 }
 
 @media (min-width: $width-ipad-landscape-min) {

--- a/src/css/modules/_speakers.scss
+++ b/src/css/modules/_speakers.scss
@@ -5,14 +5,14 @@
 }
 
 .speaker {
-    width: 100%;
-    -webkit-transition: all .3s;
     -moz-transition: all .3s;
-    transition: all .3s;
-    padding: 20px;
-    margin-top: 30px;
+    -webkit-transition: all .3s;
     border: 1px solid #f6f6f6;
     border-radius: 5px;
+    margin-top: 30px;
+    padding: 20px;
+    transition: all .3s;
+    width: 100%;
 
     &:hover {
         box-shadow: 3px 3px 10px #ccc;
@@ -41,7 +41,7 @@
 }
 
 .speaker__img {
-    max-width: 40%;
     border: 4px solid #efefef;
     border-radius: 50%;
+    max-width: 40%;
 }

--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -27,12 +27,12 @@
         text-align: center;
     }
     .footer {
-        text-align: center;
         padding: 40px 20px;
+        text-align: center;
     }
     .footer__arrow {
-        text-align: center;
         margin-top: 20px;
+        text-align: center;
     }
 }
 


### PR DESCRIPTION
## What does this change?

Fix for: #150 - Orders SCSS rules alphabetically as defined in our linter rules

## What is the benefit?

Closer to 0 linter errors. Also a little easier to find properties when they're alphabetical.
