### PR TITLE
Autoprefix SCSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,9 @@
     "sass-lint": "^1.10.2",
     "shelljs": "^0.7.3",
     "sw-precache": "^5.0.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "^6.7.7",
+    "gulp-postcss": "^6.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lint"
   ],
   "dependencies": {
+    "autoprefixer": "^6.7.7",
     "browser-sync": "^2.13.0",
     "eslint": "^3.18.0",
     "eslint-config-airbnb-base": "^11.1.2",
@@ -38,6 +39,7 @@
     "gulp-htmlmin": "^3.0.0",
     "gulp-imagemin": "^3.1.1",
     "gulp-inline": "^0.1.3",
+    "gulp-postcss": "^6.4.0",
     "gulp-preprocess": "^2.0.0",
     "gulp-sass": "^3.0.0",
     "gulp-sourcemaps": "^2.2.2",
@@ -51,9 +53,5 @@
     "sass-lint": "^1.10.2",
     "shelljs": "^0.7.3",
     "sw-precache": "^5.0.0"
-  },
-  "devDependencies": {
-    "autoprefixer": "^6.7.7",
-    "gulp-postcss": "^6.4.0"
   }
 }

--- a/src/css/base/_base.scss
+++ b/src/css/base/_base.scss
@@ -39,8 +39,6 @@ ul {
 }
 
 a {
-    -moz-transition: all .3s;
-    -webkit-transition: all .3s;
     transition: all .3s;
 }
 

--- a/src/css/components/_add-to-calendar.scss
+++ b/src/css/components/_add-to-calendar.scss
@@ -8,7 +8,6 @@
     }
 
     .atcb-link {
-        -webkit-user-select: none;
         border: 1px solid transparent;
         border-radius: 4px;
         cursor: pointer;
@@ -20,7 +19,7 @@
         touch-action: manipulation;
         vertical-align: middle;
         white-space: nowrap;
-        
+
         @include button-context($button-success-background, $button-success-text, $button-success-border);
     }
 

--- a/src/css/components/_button.scss
+++ b/src/css/components/_button.scss
@@ -1,8 +1,4 @@
 .button {
-    -moz-user-select: none;
-    -ms-touch-action: manipulation;
-    -ms-user-select: none;
-    -webkit-user-select: none;
     background-image: none;
     border: 1px solid transparent;
     border-radius: 4px;

--- a/src/css/components/_side-menu.scss
+++ b/src/css/components/_side-menu.scss
@@ -16,8 +16,6 @@
 }
 
 .side-menu__item__title {
-    -moz-transition: -moz-transform .2s, opacity .2s;
-    -webkit-transition: -webkit-transform .2s, opacity .2s;
     background-color: #659d32;
     border-radius: 3px;
     color: #ffffff;
@@ -28,15 +26,13 @@
     padding: 3px 10px;
     text-transform: uppercase;
     transition: transform .2s, opacity .2s;
-    
+
     a:hover & {
         opacity: 1;
     }
 }
 
 .side-menu__item__dot {
-    -moz-transition: all .3s;
-    -webkit-transition: all .3s;
     background-color: #659d32;
     border-radius: 2em;
     height: 10px;

--- a/src/css/modules/_speakers.scss
+++ b/src/css/modules/_speakers.scss
@@ -5,8 +5,6 @@
 }
 
 .speaker {
-    -moz-transition: all .3s;
-    -webkit-transition: all .3s;
     border: 1px solid #f6f6f6;
     border-radius: 5px;
     margin-top: 30px;

--- a/tools/tasks/css.js
+++ b/tools/tasks/css.js
@@ -4,6 +4,8 @@ const cleanCss = require('gulp-clean-css');
 const sass = require('gulp-sass');
 const preprocess = require('gulp-preprocess');
 const sourcemaps = require('gulp-sourcemaps');
+const postCss = require('gulp-postcss');
+const autoprefixer = require('autoprefixer');
 const browserSync = require('./helpers/browserSync');
 const isDev = require('./helpers/isDev');
 
@@ -18,6 +20,11 @@ module.exports = function css() {
         .pipe(sourcemaps.init())
         .pipe(sass())
         .pipe(cleanCss())
+        .pipe(postCss([
+            autoprefixer({
+                browsers: ['last 2 versions']
+            })
+        ]))
         .pipe(concat('style.css'))
         .pipe(sourcemaps.write('maps/', {
             sourceMappingURLPrefix: isDev() ? '' : '/build/css'

--- a/yarn.lock
+++ b/yarn.lock
@@ -196,6 +196,17 @@ atob@~1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/atob/-/atob-1.1.3.tgz#95f13629b12c3a51a5d215abdce2aa9f32f80773"
 
+autoprefixer@^6.7.7:
+  version "6.7.7"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-6.7.7.tgz#1dbd1c835658e35ce3f9984099db00585c782014"
+  dependencies:
+    browserslist "^1.7.6"
+    caniuse-db "^1.0.30000634"
+    normalize-range "^0.1.2"
+    num2fraction "^1.2.2"
+    postcss "^5.2.16"
+    postcss-value-parser "^3.2.3"
+
 aws-sign2@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
@@ -400,6 +411,13 @@ browser-sync@^2.13.0:
     ua-parser-js "0.7.12"
     yargs "6.4.0"
 
+browserslist@^1.7.6:
+  version "1.7.7"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-1.7.7.tgz#0bd76704258be829b2398bb50e4b62d1a166b0b9"
+  dependencies:
+    caniuse-db "^1.0.30000639"
+    electron-to-chromium "^1.2.7"
+
 bs-recipes@1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/bs-recipes/-/bs-recipes-1.3.4.tgz#0d2d4d48a718c8c044769fdc4f89592dc8b69585"
@@ -489,6 +507,10 @@ camelcase@^2.0.0, camelcase@^2.1.0:
 camelcase@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
+
+caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
+  version "1.0.30000646"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000646.tgz#c724b90d61df24286e015fc528d062073c00def4"
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"
@@ -766,6 +788,17 @@ cookie@0.3.1:
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+
+cosmiconfig@^2.1.0, cosmiconfig@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-2.1.1.tgz#817f2c2039347a1e9bf7d090c0923e53f749ca82"
+  dependencies:
+    js-yaml "^3.4.3"
+    minimist "^1.2.0"
+    object-assign "^4.1.0"
+    os-homedir "^1.0.1"
+    parse-json "^2.2.0"
+    require-from-string "^1.1.0"
 
 create-error-class@^3.0.1:
   version "3.0.2"
@@ -1129,6 +1162,10 @@ ecc-jsbn@~0.1.1:
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+
+electron-to-chromium@^1.2.7:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.2.tgz#b8ce5c93b308db0e92f6d0435c46ddec8f6363ab"
 
 emitter-steward@^1.0.0:
   version "1.0.0"
@@ -2088,6 +2125,15 @@ gulp-inline@^0.1.3:
     gulp-util "^3.0.7"
     through2 "^2.0.3"
 
+gulp-postcss@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/gulp-postcss/-/gulp-postcss-6.4.0.tgz#78a32e3c87aa6cdcec5ae1c905e196d478e8c5d5"
+  dependencies:
+    gulp-util "^3.0.8"
+    postcss "^5.2.12"
+    postcss-load-config "^1.2.0"
+    vinyl-sourcemaps-apply "^0.2.1"
+
 gulp-preprocess@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/gulp-preprocess/-/gulp-preprocess-2.0.0.tgz#067bf6a4e1b703d7b45ed2047ce7e87d5974d241"
@@ -2233,6 +2279,10 @@ has-binary@0.1.7:
 has-cors@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/has-cors/-/has-cors-1.1.0.tgz#5e474793f7ea9843d1bb99c23eef49ff126fff39"
+
+has-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
 has-gulplog@^0.1.0:
   version "0.1.0"
@@ -2722,11 +2772,15 @@ jpegtran-bin@^3.0.0:
     bin-wrapper "^3.0.0"
     logalot "^2.0.0"
 
+js-base64@^2.1.9:
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.1.9.tgz#f0e80ae039a4bd654b5f281fc93f04a914a7fcce"
+
 js-tokens@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.0.tgz#a2f2a969caae142fb3cd56228358c89366957bd1"
 
-js-yaml@^3.4.6, js-yaml@^3.5.1, js-yaml@^3.5.4, js-yaml@~3.7.0:
+js-yaml@^3.4.3, js-yaml@^3.4.6, js-yaml@^3.5.1, js-yaml@^3.5.4, js-yaml@~3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
   dependencies:
@@ -3391,6 +3445,10 @@ normalize-path@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.0.1.tgz#47886ac1662760d4261b7d979d241709d3ce3f7a"
 
+normalize-range@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -3411,6 +3469,10 @@ nth-check@~1.0.1:
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.1.tgz#9929acdf628fc2c41098deab82ac580cf149aae4"
   dependencies:
     boolbase "~1.0.0"
+
+num2fraction@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede"
 
 number-is-nan@^1.0.0:
   version "1.0.1"
@@ -3722,6 +3784,42 @@ portscanner@2.1.1:
     async "1.5.2"
     is-number-like "^1.0.3"
 
+postcss-load-config@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-1.2.0.tgz#539e9afc9ddc8620121ebf9d8c3673e0ce50d28a"
+  dependencies:
+    cosmiconfig "^2.1.0"
+    object-assign "^4.1.0"
+    postcss-load-options "^1.2.0"
+    postcss-load-plugins "^2.3.0"
+
+postcss-load-options@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/postcss-load-options/-/postcss-load-options-1.2.0.tgz#b098b1559ddac2df04bc0bb375f99a5cfe2b6d8c"
+  dependencies:
+    cosmiconfig "^2.1.0"
+    object-assign "^4.1.0"
+
+postcss-load-plugins@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz#745768116599aca2f009fad426b00175049d8d92"
+  dependencies:
+    cosmiconfig "^2.1.1"
+    object-assign "^4.1.0"
+
+postcss-value-parser@^3.2.3:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz#87f38f9f18f774a4ab4c8a232f5c5ce8872a9d15"
+
+postcss@^5.2.12, postcss@^5.2.16:
+  version "5.2.16"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.16.tgz#732b3100000f9ff8379a48a53839ed097376ad57"
+  dependencies:
+    chalk "^1.1.3"
+    js-base64 "^2.1.9"
+    source-map "^0.5.6"
+    supports-color "^3.2.3"
+
 pre-commit@^1.1.3:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/pre-commit/-/pre-commit-1.2.2.tgz#dbcee0ee9de7235e57f79c56d7ce94641a69eec6"
@@ -4008,6 +4106,10 @@ request@^2.79.0:
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+
+require-from-string@^1.1.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-1.2.1.tgz#529c9ccef27380adfec9a2f965b649bbee636418"
 
 require-main-filename@^1.0.1:
   version "1.0.1"
@@ -4314,7 +4416,7 @@ source-map-url@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.3.0.tgz#7ecaf13b57bcd09da8a40c5d269db33799d4aaf9"
 
-source-map@0.5.x, source-map@0.X, source-map@^0.5.1, source-map@^0.5.3, source-map@~0.5.1:
+source-map@0.5.x, source-map@0.X, source-map@^0.5.1, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
@@ -4525,6 +4627,12 @@ supports-color@^0.2.0:
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+
+supports-color@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
+  dependencies:
+    has-flag "^1.0.0"
 
 svgo@^0.7.0:
   version "0.7.2"


### PR DESCRIPTION
## What does this change?

It's a sad state of affairs, adding vendor prefixes to all our SCSS. Who knows what browsers we're covering and what we're missing? Let's allow Gulp to take care of it!

## What is the benefit?

- We can now [explicitly declare which browsers we support](https://github.com/WDOTS/wdots.github.io/blob/4729c490d946d3b3908bde6f3ce5b98f61e9954d/tools/tasks/css.js#L25), and hence which vendor prefixes will be added ✅ 
- Less code for us to worry about ⬇️ 
- Also fixes all the vendor prefixing Sass Lint warnings 🛠 
- In reality, this has just added some old IE flex support :man_shrugging: 