### PR TITLE
Upgrade eslint config airbnb base 11.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "autoprefixer": "^6.7.7",
     "browser-sync": "^2.13.0",
-    "eslint": "^3.18.0",
+    "eslint": "^3.19.0",
     "eslint-config-airbnb-base": "^11.1.3",
     "eslint-plugin-import": "^2.2.0",
     "gulp": "^3.9.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "autoprefixer": "^6.7.7",
     "browser-sync": "^2.13.0",
     "eslint": "^3.18.0",
-    "eslint-config-airbnb-base": "^11.1.2",
+    "eslint-config-airbnb-base": "^11.1.3",
     "eslint-plugin-import": "^2.2.0",
     "gulp": "^3.9.1",
     "gulp-clean-css": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1315,9 +1315,9 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-config-airbnb-base@^11.1.2:
-  version "11.1.2"
-  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-11.1.2.tgz#259209a7678bf693e31cbe8f953f206b6aa7ccc3"
+eslint-config-airbnb-base@^11.1.3:
+  version "11.1.3"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-11.1.3.tgz#0e8db71514fa36b977fbcf977c01edcf863e0cf0"
 
 eslint-import-resolver-node@^0.2.0:
   version "0.2.3"
@@ -1387,9 +1387,9 @@ eslint@^2.7.0:
     text-table "~0.2.0"
     user-home "^2.0.0"
 
-eslint@^3.18.0:
-  version "3.18.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.18.0.tgz#647e985c4ae71502d20ac62c109f66d5104c8a4b"
+eslint@^3.19.0:
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.19.0.tgz#c8fc6201c7f40dd08941b87c085767386a679acc"
   dependencies:
     babel-code-frame "^6.16.0"
     chalk "^1.1.3"


### PR DESCRIPTION
## What does this change?

- Upgrades eslint-config-airbnb-base to v11.1.3
- Also upgrades `peerDependency` eslint to v3.19.0

## What is the benefit?

Fixes #159 , deps up to date
